### PR TITLE
Fix missing sourcemap warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export default (
 
       return {
         code: `const data = ${toSource(yamlData)};\nexport default data;`,
+        map: { mappings: "" },
       };
     }
     return null;


### PR DESCRIPTION
Provide an empty source map to Rollup to avoid it warning on missing sourcemap.

Another option is to provide `null` which should be used when the "transformation does not move code", but I think it is more appropriate to indicate "sourcemap does not make sense" instead.

Ref: https://rollupjs.org/guide/en/#source-code-transformations
Related: https://github.com/Modyfi/vite-plugin-yaml/issues/3