### PR TITLE
Remove pnpm-only restriction on preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "license": "MIT",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "dev": "tsup --watch src",
     "example:dev": "pnpm -C example run dev",
     "example:build": "pnpm run build && pnpm -C example run build",


### PR DESCRIPTION
Resolves #7 by removing restriction meant for local plugin development which unintentionally affects the end-user plugin usage in Node 14 + npm