### PR TITLE
Add vite 6 to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/Modyfi/vite-plugin-yaml/tree/main/#readme",
   "peerDependencies": {
-    "vite": "^3.2.7 || ^4.0.5 || ^5.0.5"
+    "vite": "^3.2.7 || ^4.0.5 || ^5.0.5 || ^6.0.3"
   },
   "dependencies": {
     "@rollup/pluginutils": "5.1.0",


### PR DESCRIPTION
As far as I'm aware, the plugin API of v6 is compatible to v5, so this should be all that's needed to support v6.